### PR TITLE
vue_awesome_paginateを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.2.45",
+        "vue-awesome-paginate": "^1.1.46",
         "vue-router": "^4.1.6"
       },
       "devDependencies": {
@@ -1681,6 +1682,14 @@
         "@vue/shared": "3.2.47"
       }
     },
+    "node_modules/vue-awesome-paginate": {
+      "version": "1.1.46",
+      "resolved": "https://registry.npmjs.org/vue-awesome-paginate/-/vue-awesome-paginate-1.1.46.tgz",
+      "integrity": "sha512-hjwAJLd2N54j0uuGgqmlTdhZw8NBFQpFiShjGrvxsA0DnvmOQjM18GEor+Ieigz6nE8VA4hQerIDBQjf4lsacg==",
+      "dependencies": {
+        "vue": "^3.2.25"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.6.tgz",
@@ -2787,6 +2796,14 @@
         "@vue/runtime-dom": "3.2.47",
         "@vue/server-renderer": "3.2.47",
         "@vue/shared": "3.2.47"
+      }
+    },
+    "vue-awesome-paginate": {
+      "version": "1.1.46",
+      "resolved": "https://registry.npmjs.org/vue-awesome-paginate/-/vue-awesome-paginate-1.1.46.tgz",
+      "integrity": "sha512-hjwAJLd2N54j0uuGgqmlTdhZw8NBFQpFiShjGrvxsA0DnvmOQjM18GEor+Ieigz6nE8VA4hQerIDBQjf4lsacg==",
+      "requires": {
+        "vue": "^3.2.25"
       }
     },
     "vue-router": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "vue": "^3.2.45",
+    "vue-awesome-paginate": "^1.1.46",
     "vue-router": "^4.1.6"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
-
 import router from './router'
+import VueAwesomePaginate from "vue-awesome-paginate";
+import "vue-awesome-paginate/dist/style.css";
 
 const app = createApp(App)
 
 app.use(router)
+app.use(VueAwesomePaginate)
 
 app.mount('#app')

--- a/src/views/recordings/RecordingSearch.vue
+++ b/src/views/recordings/RecordingSearch.vue
@@ -1,4 +1,54 @@
+<script setup lang="ts">
+  import { ref, onMounted } from "vue";
+
+    const onClickHandler = async (page: number) => {
+      console.log(page);
+      const term = "ありがとう"
+      const res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${term}&offset=&${page}&fmt=json`)
+      const data = await res.json();
+      console.log(data);
+    };
+
+    const currentPage = ref(1);
+
+    onMounted(() => {
+      onClickHandler(currentPage.value)
+    })
+</script>
+
 <template>
-楽曲検索結果です
+  <vue-awesome-paginate
+    :total-items="50"
+    :items-per-page="5"
+    :max-pages-shown="5"
+    v-model="currentPage"
+    :on-click="onClickHandler"
+  />
 </template>
 
+<style>
+  .pagination-container {
+    display: flex;
+    column-gap: 10px;
+  }
+  .paginate-buttons {
+    height: 40px;
+    width: 40px;
+    border-radius: 20px;
+    cursor: pointer;
+    background-color: rgb(242, 242, 242);
+    border: 1px solid rgb(217, 217, 217);
+    color: black;
+  }
+  .paginate-buttons:hover {
+    background-color: #d8d8d8;
+  }
+  .active-page {
+    background-color: #3498db;
+    border: 1px solid #3498db;
+    color: white;
+  }
+  .active-page:hover {
+    background-color: #2988c8;
+  }
+</style>


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/67
https://github.com/fuwa-syugyo/credit_search/issues/69

## 概要
ページネーション用ライブラリ`vue_awesome_paginate`を導入した。
ページにアクセスした時&ページを切り替えたときにfetchリクエストを行い、楽曲検索結果をコンソール上に表示するようにした。
画面表示は別のPRで対応する。