### PR TITLE
楽曲検索結果に曲詳細へのリンクをつけた

### DIFF
--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { RouterLink, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 
 const router = useRouter();
 const term = ref('');

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
   import { ref, onMounted } from "vue";
 
+  interface Props {
+    id: string;
+  }
+  const props = defineProps<Props>();
+  const recording_id = props.id
   const credit_data = ref<RecordingData[]>([]);
 
   type Staff = {
@@ -50,7 +55,6 @@
     };
 
     onMounted(async () => {
-      const recording_id = "7c8ca692-d78a-4785-a7f4-7cc9ed0fb0f5"
       const res = await fetch(`https://musicbrainz.org/ws/2/recording/${recording_id}?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels&fmt=json`)
       const data = await res.json()
 
@@ -98,7 +102,7 @@
           }
         };
         credit_data.value = all_credit_data;
-        console.log(credit_data.value)
+        console.log(all_credit_data)
 
     })
 </script>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref, onMounted } from "vue";
-  import {useRoute} from "vue-router";
+  import { useRoute, RouterLink } from "vue-router";
 
   const route = useRoute();
   const recording_term = route.query.term;
@@ -68,7 +68,9 @@
     </thead>
     <tbody>
       <tr v-for="recording in recording_data" :key="recording.id">
+        <RouterLink v-bind:to="{name: 'RecordingDetail', params: {id: recording.id}}">
         <td>{{ recording.title }}</td>
+        </RouterLink>
         <td>{{ recording.artist }}</td>
         <td>{{ recording.first_release_date }}</td>
       </tr>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,6 +30,12 @@ const routeSettings: RouteRecordRaw[] = [
     name: 'RecordingDetail',
     component: () => {
       return import("../components/recordings/RecordingDetail.vue");
+    },
+    props: (routes) => {
+      const idStr = String(routes.params.id);
+      return {
+        id: idStr
+      };
     }
   },
 


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/85

## 概要
楽曲検索結果の曲名をクリックすると、その曲の詳細画面に遷移するようにした。

## 後でやること
* 曲詳細画面の情報がおかしい曲がある
https://github.com/fuwa-syugyo/credit_search/issues/89
![image](https://user-images.githubusercontent.com/62344131/224888875-e4730cc0-7fed-4a54-91db-fc4443099275.png)

![image](https://user-images.githubusercontent.com/62344131/224888924-2c0b2d84-f564-495f-af6d-4b14623c12ac.png)

