### PR TITLE
アーティスト名をすべて表示する＆詳細画面へのリンクをつけた

### DIFF
--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -106,25 +106,33 @@
         <tbody v-if="credit_data?.credit.songwriter_credit">
           <tr v-for="songwriter in credit_data.credit.songwriter_credit" v-bind:key="songwriter.id">
             <td>{{ songwriter.type }}</td>
-            <td>{{ songwriter.name }}</td>
+            <RouterLink v-bind:to="{name: 'ArtistDetail', params: {id: songwriter.id}}">
+              <td>{{ songwriter.name }}</td>
+            </RouterLink>
           </tr>
         </tbody>
         <tbody v-if="credit_data?.credit.staff_credit">
           <tr v-for="staff in credit_data.credit.staff_credit" v-bind:key="staff.id">
             <td>{{ staff.type }}</td>
-            <td>{{ staff.name }}</td>
+            <RouterLink v-bind:to="{name: 'ArtistDetail', params: {id: staff.id}}">
+              <td>{{ staff.name }}</td>
+            </RouterLink>
           </tr>
         </tbody>
         <tbody v-if="credit_data?.credit.player_credit">
           <tr v-for="player in credit_data.credit.player_credit" v-bind:key="player.id">
             <td>{{ player.instrument }}</td>
-            <td>{{ player.name }}</td>
+            <RouterLink v-bind:to="{name: 'ArtistDetail', params: {id: player.id}}">
+              <td>{{ player.name }}</td>
+            </RouterLink>
           </tr>
         </tbody>
         <tbody v-if="credit_data?.credit.engineer_credit">
           <tr v-for="engineer in credit_data.credit.engineer_credit" v-bind:key="engineer.id">
             <td>{{ engineer.type }}</td>
-            <td>{{ engineer.name }}</td>
+            <RouterLink v-bind:to="{name: 'ArtistDetail', params: {id: engineer.id}}">
+              <td>{{ engineer.name }}</td>
+            </RouterLink>
           </tr>
         </tbody>
       </table>

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -80,11 +80,15 @@
       <tbody>
         <tr v-if="credit_data?.credit">
           <td>{{ credit_data?.title }}</td>
-          <td
-            v-for="(artist) in credit_data.credit.artist_credit" :key="artist.index"
-            v-bind:name="artist.artist.name"
-            v-bind:joinphrase="artist.joinphrase">
-            {{ artist.artist.name }}{{ artist.joinphrase }}
+          <td>
+            <span v-for="(artist) in credit_data.credit.artist_credit" :key="artist.index"
+              v-bind:name="artist.artist.name"
+              v-bind:joinphrase="artist.joinphrase">
+              <RouterLink v-bind:to="{name: 'ArtistDetail', params: {id: artist.artist.id}}">
+                {{ artist.artist.name }}
+              </RouterLink>
+                {{ artist.joinphrase }}
+            </span>
           </td>
         </tr>
       </tbody>

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -15,10 +15,6 @@
 
       const artists: Artists[] = data["artist-credit"]
 
-      artists.forEach((element, index) => {
-        element.index = index + 1;
-      });
-
       const player: Player[] = data.relations.filter((rec: Player) => rec.type == "instrument" || rec.type == "vocal").map((item: Player) => ({
         id: item.artist.id,
         type: item.type,
@@ -81,7 +77,7 @@
         <tr v-if="credit_data?.credit">
           <td>{{ credit_data?.title }}</td>
           <td>
-            <span v-for="(artist) in credit_data.credit.artist_credit" :key="artist.index"
+            <span v-for="artist in credit_data.credit.artist_credit"
               v-bind:name="artist.artist.name"
               v-bind:joinphrase="artist.joinphrase">
               <RouterLink v-bind:to="{name: 'ArtistDetail', params: {id: artist.artist.id}}">

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref, onMounted } from "vue";
-  import { RecordingData, Staff, SongWriter, Player, Engineer } from "../../types/recording/RecordingDetail"
+  import { RecordingData, Artists, Staff, SongWriter, Player, Engineer } from "../../types/recording/RecordingDetail"
 
   interface Props {
     id: string;
@@ -12,6 +12,12 @@
     onMounted(async () => {
       const res = await fetch(`https://musicbrainz.org/ws/2/recording/${recording_id}?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels&fmt=json`)
       const data = await res.json()
+
+      const artists: Artists[] = data["artist-credit"]
+
+      artists.forEach((element, index) => {
+        element.index = index + 1;
+      });
 
       const player: Player[] = data.relations.filter((rec: Player) => rec.type == "instrument" || rec.type == "vocal").map((item: Player) => ({
         id: item.artist.id,
@@ -49,7 +55,7 @@
           attribute: data?.relations?.filter((item: RecordingData )=> item)[0]?.attributes,
 
           credit: {
-            artist_credit: { artist_credit_id: data?.['artist-credit'][0].artist.id, artist_credit: data?.['artist-credit'][0].name},
+            artist_credit: artists,
             songwriter_credit: songwriter,
             staff_credit: staff,
             player_credit: player,
@@ -74,7 +80,12 @@
       <tbody>
         <tr v-if="credit_data?.credit">
           <td>{{ credit_data?.title }}</td>
-          <td>{{ credit_data?.credit.artist_credit.artist_credit }}</td>
+          <td
+            v-for="(artist) in credit_data.credit.artist_credit" :key="artist.index"
+            v-bind:name="artist.artist.name"
+            v-bind:joinphrase="artist.joinphrase">
+            {{ artist.artist.name }}{{ artist.joinphrase }}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -46,7 +46,7 @@
         const new_recording_data: SearchRecordingData[] = data.recordings.filter((rec:SearchRecordingData) => rec).map((item: SearchRecordingData) => ({
           id: item.id,
           title: item.title,
-          "artist-credit": [item["artist-credit"]].flat().map(credit => ({
+          "artist-credit": item["artist-credit"].map(credit => ({
             id: credit.artist.id,
             name: credit.artist.name,
             join_phrase: credit.joinphrase,
@@ -122,7 +122,8 @@
   }
 
   td, th {
-    border: 1px solid black;
-    padding: 0.5em;
+    padding: 10px;
+    vertical-align: middle;
+    border-bottom: 1px solid black;
   }
 </style>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import { ref, onMounted } from "vue";
   import { useRoute, RouterLink } from "vue-router";
-  import { SearchRecordingData } from "../../types/recording/RecordingSearch"
+  import { ArtistCredit, SearchRecordingData } from "../../types/recording/RecordingSearch"
 
   const route = useRoute();
   const recording_term = route.query.term;
@@ -15,15 +15,18 @@
     const res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=${offset}&limit=100&fmt=json`)
     const data = await res.json();
 
-  const new_recording_data: SearchRecordingData[] = data.recordings.filter((rec:SearchRecordingData) => rec).map((item: SearchRecordingData) => ({
-    id: item.id,
-    title: item.title,
-    artist: {
-      id:item["artist-credit"][0].id,
-      name: item["artist-credit"][0].name,
-    },
-    first_release_date: item["first-release-date"]
-  }))
+    const new_recording_data: SearchRecordingData[] = data.recordings.filter((rec:SearchRecordingData) => rec).map((item: SearchRecordingData) => ({
+          id: item.id,
+          title: item.title,
+          "artist-credit": item["artist-credit"].map(credit => ({
+            id: credit.artist.id,
+            name: credit.artist.name,
+            join_phrase: credit.joinphrase,
+            all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
+          })),
+          first_release_date: item["first-release-date"]
+        }))
+  console.log(new_recording_data)
 
   recording_data.value = new_recording_data;
   totalItems.value = data.count - 1;
@@ -43,12 +46,15 @@
         const new_recording_data: SearchRecordingData[] = data.recordings.filter((rec:SearchRecordingData) => rec).map((item: SearchRecordingData) => ({
           id: item.id,
           title: item.title,
-          artist: {
-            id:item["artist-credit"][0].id,
-            name: item["artist-credit"][0].name,
-          },
+          "artist-credit": [item["artist-credit"]].flat().map(credit => ({
+            id: credit.artist.id,
+            name: credit.artist.name,
+            join_phrase: credit.joinphrase,
+            all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
+          })),
           first_release_date: item["first-release-date"]
-      }))
+        }))
+
       all_recording_data.value.push(new_recording_data);
       }
       const flatted_recording_data = all_recording_data.value.flat();
@@ -69,9 +75,9 @@
     <tbody>
       <tr v-for="recording in recording_data" :key="recording.id">
         <RouterLink v-bind:to="{name: 'RecordingDetail', params: {id: recording.id}}">
-        <td>{{ recording.title }}</td>
+          <td>{{ recording.title }}</td>
         </RouterLink>
-        <td>{{ recording.artist.name }}</td>
+        <td>{{ recording["artist-credit"].map((credit: ArtistCredit) => credit.all_name).join(' ') }}</td>
         <td>{{ recording.first_release_date }}</td>
       </tr>
     </tbody>
@@ -85,7 +91,7 @@
   />
 </template>
 
-<style>
+<style scoped>
   .pagination-container {
     display: flex;
     column-gap: 10px;
@@ -109,5 +115,14 @@
   }
   .active-page:hover {
     background-color: #2988c8;
+  }
+
+  table {
+  border-collapse: collapse;
+  }
+
+  td, th {
+    border: 1px solid black;
+    padding: 0.5em;
   }
 </style>

--- a/src/types/recording/RecordingDetail.ts
+++ b/src/types/recording/RecordingDetail.ts
@@ -47,11 +47,17 @@ export type Engineer = {
   }
 }
 
-export type Credit = {
-  artist_credit: {
-    artist_credit_id: string;
-    artist_credit: string;
+export type Artists = {
+  index: number;
+  artist: {
+    id: string;
+    name: string;
   }
+  joinphrase: string;
+}
+
+export type Credit = {
+  artist_credit: Artists[];
   songwriter_credit: SongWriter[];
   staff_credit: Staff[];
   player_credit: Player[];

--- a/src/types/recording/RecordingSearch.ts
+++ b/src/types/recording/RecordingSearch.ts
@@ -1,6 +1,12 @@
 export type ArtistCredit = {
   id: string;
   name: string;
+  artist: {
+    id: string;
+    name: string;
+  }
+  joinphrase: string;
+  all_name: string;
 }
 
 export type SearchRecordingData  = {
@@ -8,9 +14,5 @@ export type SearchRecordingData  = {
   title: string;
   "artist-credit": ArtistCredit[];
   "first-release-date": string;
-  artist: {
-    id: string;
-    name: string;
-  }
   first_release_date: string;
   };


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/78
https://github.com/fuwa-syugyo/credit_search/issues/82

## 概要
* 曲検索画面にアーティスト名を全て表示するようにした
今までは複数アーティストがいるときは最初の一人しか表示されていなかったので修正した。
詳細画面へのリンクはまぁ不要かなということで現時点ではつけていない。検索しているのは曲だし。
* 曲詳細画面の人物名をクリックすると詳細画面に遷移するようにした