### PR TITLE
人物詳細画面の曲名にリンクをつけた

### DIFF
--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -87,7 +87,9 @@
         <tbody v-if="artist_data?.credit.recording_credit">
           <tr v-for="recording in artist_data.credit.recording_credit" v-bind:key="recording.recording.id">
             <td>{{ recording.type }}</td>
-            <td>{{ recording.recording.title }}</td>
+            <RouterLink v-bind:to="{name: 'RecordingDetail', params: {id: recording.recording.id}}">
+              <td>{{ recording.recording.title }}</td>
+            </RouterLink>
           </tr>
         </tbody>
       </table>

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
   import { ref, onMounted, defineProps } from "vue";
   import { ArtistData, RecordingCredit, SongWriterCredit, RecordInWork, ArtistCredit } from "../../types/artist/ArtistDetail"
-  // import WorkModal from "./WorkModal.vue";
 
   interface Props {
     id: string;
@@ -88,7 +87,11 @@
         <tbody v-if="artist_data?.credit.song_writer_credit">
           <tr v-for="songwriter in artist_data.credit.song_writer_credit" v-bind:key="songwriter.work.id">
             <td>{{ songwriter.type }}</td>
-            <td @click="recordingInWork(songwriter.work.id)">{{ songwriter.work.title }}</td>
+            <td>
+            <RouterLink v-bind:to="{name: 'RecordingInWork', params: {id: songwriter.work.id}}">
+              {{ songwriter.work.title }}
+            </RouterLink>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -8,24 +8,6 @@
   const props = defineProps<Props>();
   const artist_data = ref<ArtistData>();
 
-  const recordingInWork = async (work_id: string) => {
-    const res = await fetch(`https://musicbrainz.org/ws/2/work/${work_id}?inc=recording-rels+artist-credits&fmt=json`)
-    const data = await res.json();
-
-    let recording_in_work: RecordInWork = data?.relations.filter((x: Array<object>) => x).map((item: RecordInWork) => ({
-        id: item.recording.id,
-        title: item.recording.title,
-        "artist-credit": item.recording["artist-credit"].map((credit: ArtistCredit) => ({
-            id: credit.artist.id,
-            name: credit.artist.name,
-            join_phrase: credit.joinphrase,
-            all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
-          })),
-        attributes: item.attributes[0],
-      }))
-      console.log(recording_in_work)
-    }
-
   onMounted(async () => {
     const res = await fetch(`https://musicbrainz.org/ws/2/artist/${props.id}?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json`)
     const data = await res.json()

--- a/src/components/recordings/RecordingInWork.vue
+++ b/src/components/recordings/RecordingInWork.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+  import { ref, onMounted } from "vue";
+  import { RouterLink } from "vue-router";
+  import { RecordInWork } from "../../types/artist/ArtistDetail"
+  import { ArtistCredit } from "../../types/recording/RecordingSearch"
+
+  interface Props {
+    id: string;
+  }
+  const props = defineProps<Props>();
+  const work_id = props.id
+
+  const recording_list = ref<RecordInWork[]>();
+
+  onMounted(async () => {
+    const res = await fetch(`https://musicbrainz.org/ws/2/work/${work_id}?inc=recording-rels+artist-credits&fmt=json`)
+    const data = await res.json()
+
+    const recording_in_work: RecordInWork[] = data?.relations.filter((x: Array<object>) => x).map((item: RecordInWork) => ({
+      id: item.recording.id,
+      title: item.recording.title,
+      "artist-credit": item.recording["artist-credit"].map((credit: ArtistCredit) => ({
+          id: credit.artist.id,
+          name: credit.artist.name,
+          join_phrase: credit.joinphrase,
+          all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
+        })),
+      attributes: item.attributes[0],
+    }))
+    console.log(recording_in_work)
+    recording_list.value = recording_in_work;
+  })
+</script>
+
+<template>
+  <table>
+    <thead>
+      <tr>
+        <th>曲名</th>
+        <th>アーティスト</th>
+        <th>属性</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="recording in recording_list" :key="recording.id">
+        <RouterLink v-bind:to="{name: 'RecordingDetail', params: {id: recording.id}}">
+          <td>{{ recording.title }}</td>
+        </RouterLink>
+        <td>{{ recording["artist-credit"].map((credit: ArtistCredit) => credit.all_name).join(' ') }}</td>
+        <td>{{ recording.attributes }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style scoped>
+  .pagination-container {
+    display: flex;
+    column-gap: 10px;
+  }
+  .paginate-buttons {
+    height: 40px;
+    width: 40px;
+    border-radius: 20px;
+    cursor: pointer;
+    background-color: rgb(242, 242, 242);
+    border: 1px solid rgb(217, 217, 217);
+    color: black;
+  }
+  .paginate-buttons:hover {
+    background-color: #d8d8d8;
+  }
+  .active-page {
+    background-color: #3498db;
+    border: 1px solid #3498db;
+    color: white;
+  }
+  .active-page:hover {
+    background-color: #2988c8;
+  }
+
+  table {
+  border-collapse: collapse;
+  }
+
+  td, th {
+    padding: 10px;
+    vertical-align: middle;
+    border-bottom: 1px solid black;
+  }
+</style>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -16,21 +16,21 @@
     const data = await res.json();
 
     const new_recording_data: SearchRecordingData[] = data.recordings.filter((rec:SearchRecordingData) => rec).map((item: SearchRecordingData) => ({
-          id: item.id,
-          title: item.title,
-          "artist-credit": item["artist-credit"].map(credit => ({
-            id: credit.artist.id,
-            name: credit.artist.name,
-            join_phrase: credit.joinphrase,
-            all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
-          })),
-          first_release_date: item["first-release-date"]
-        }))
-  console.log(new_recording_data)
+      id: item.id,
+      title: item.title,
+      "artist-credit": item["artist-credit"].map(credit => ({
+        id: credit.artist.id,
+        name: credit.artist.name,
+        join_phrase: credit.joinphrase,
+        all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
+      })),
+      first_release_date: item["first-release-date"]
+    }))
+    console.log(new_recording_data)
 
-  recording_data.value = new_recording_data;
-  totalItems.value = data.count - 1;
-}
+    recording_data.value = new_recording_data;
+    totalItems.value = data.count - 1;
+    }
 
   const currentPage = ref(1);
   const totalItems = ref(0);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,6 +40,20 @@ const routeSettings: RouteRecordRaw[] = [
   },
 
   {
+    path: '/recordings/work/:id',
+    name: 'RecordingInWork',
+    component: () => {
+      return import("../components/recordings/RecordingInWork.vue");
+    },
+    props: (routes) => {
+      const idStr = String(routes.params.id);
+      return {
+        id: idStr
+      };
+    }
+  },
+
+  {
     path: '/artists/:id',
     name: 'ArtistDetail',
     component: () => {

--- a/src/types/artist/ArtistDetail.ts
+++ b/src/types/artist/ArtistDetail.ts
@@ -25,3 +25,23 @@ export type ArtistData = {
   }
 }
 
+export type ArtistCredit = {
+  id: string;
+  name: string;
+  artist: {
+    id: string;
+    name: string;
+  }
+  joinphrase: string;
+  all_name: string;
+}
+
+export type RecordInWork = {
+  recording: {
+    id: string;
+    title: string;
+    "artist-credit": ArtistCredit[];
+  }
+  attributes: Array<string>;
+}
+

--- a/src/types/artist/ArtistDetail.ts
+++ b/src/types/artist/ArtistDetail.ts
@@ -42,6 +42,9 @@ export type RecordInWork = {
     title: string;
     "artist-credit": ArtistCredit[];
   }
+  id: string;
+  title: string;
   attributes: Array<string>;
+  "artist-credit": ArtistCredit[];
 }
 


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/94
https://github.com/fuwa-syugyo/credit_search/issues/98

## 概要
人物詳細画面に表示されている曲名にその曲の詳細画面へのリンクをつけた。
作詞作曲の曲名については、workをfetchしてrecordingの一覧を新しいページで表示することにした。
本当はモーダルで表示したかったが、他の優先度が高いタスクを先に行う。

## あとでやること
* work画面にrecordingの並び替え、抽出機能を追加
https://github.com/fuwa-syugyo/credit_search/issues/99
https://github.com/fuwa-syugyo/credit_search/issues/100
* workにrecordingが1曲しかない場合、work画面を挟まずに曲詳細画面に直接遷移する機能の追加
https://github.com/fuwa-syugyo/credit_search/issues/101
* work画面から明らかにクレジット情報を取得する価値がない曲(TVサイズやinstrumental音源)を除外
https://github.com/fuwa-syugyo/credit_search/issues/102