### PR TITLE
曲検索結果画面に絞り込み機能を追加した

### DIFF
--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { useRouter } from 'vue-router'
+import { useRouter, NavigationFailureType, isNavigationFailure } from 'vue-router'
 
 const router = useRouter();
 const term = ref('');
@@ -8,7 +8,7 @@ const searchType = ref('曲名')
 
 const search = (): void => {
   const type = searchType.value === '曲名' ? 'Recording' : 'Artist';
-  router.push({ name: type + 'Search', query: { term: term.value} });
+  router.push({ name: type + 'Search', query: { term: term.value}})
 }
 
 </script>

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -10,7 +10,6 @@
   const all_artist_data = ref<Array<ArtistData[]>>([]);
 
   const onClickHandler = async (page: number) => {
-    console.log(page);
     const offset = (page - 1) * 100
     const res = await fetch(`https://musicbrainz.org/ws/2/artist/?query=artist:${artist_term}&offset=${offset}&limit=100&fmt=json`)
     const data = await res.json();
@@ -40,6 +39,7 @@
           name: item.name,
       }))
       all_artist_data.value.push(new_artist_data);
+      totalItems.value = data.count - 1;
       }
       const flatted_artist_data = all_artist_data.value.flat();
       console.log(flatted_artist_data);

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -19,6 +19,9 @@
   const recording_data = ref<SearchRecordingData[]>([]);
   const all_recording_data = ref<Array<SearchRecordingData[]>>([]);
 
+  const selectFilter = ref<Array<string>>([]);
+  const artistName = ref();
+
   const onClickHandler = async (page: number) => {
     const offset = (page - 1) * 100
     const res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=${offset}&limit=100&fmt=json`)
@@ -43,12 +46,21 @@
   const currentPage = ref(1);
   const totalItems = ref(0);
 
-  const toFilter = (): void => {
+  const applyFilter = () :void  => {
+    const getRidOfInstrumentAndLiveValue = selectFilter.value.includes("getRidOfInstrumentAndLive")? 'true': 'false';
+    const getExactMatchValue = selectFilter.value.includes("getExactMatch")? 'true': 'false';
+
     router.push({
     name: "RecordingSearchFilter",
-    query: { term: recording_term },
-  });
+    query: { term: recording_term,
+            getRidOfInstrumentAndLive: getRidOfInstrumentAndLiveValue,
+            getExactMatch: getExactMatchValue,
+            artistName: artistName.value
+            },
+    });
   }
+
+
 
   onMounted(async () => {
     await onClickHandler(currentPage.value);
@@ -79,8 +91,18 @@
 </script>
 
 <template>
-  <div>
-    <button v-on:click="toFilter">絞り込み</button>
+  <div class="container px-4 my-4 border border-gray-700 py-4">
+    <form v-on:submit.prevent="applyFilter">
+      <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外  </label>
+      <label><input type="checkbox" v-model="selectFilter" value="getExactMatch">完全一致の曲のみ</label>
+      <br>
+      <label>アーティスト名で絞り込み</label>
+      <div class="relative">
+        <input v-model="artistName" type="search" id="search" class=" p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="アーティスト名を入力" />
+          <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none"></div>
+          <button type="submit" class="text-white absolute right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800">適用</button>
+      </div>
+    </form>
   </div>
   <table class="table-auto my-4">
     <thead>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -48,13 +48,13 @@
 
   const applyFilter = () :void  => {
     const getRidOfInstrumentAndLiveValue = selectFilter.value.includes("getRidOfInstrumentAndLive")? 'true': 'false';
-    const getExactMatchValue = selectFilter.value.includes("getExactMatch")? 'true': 'false';
+    const getPartialMatchValue = selectFilter.value.includes("getPartialMatch")? 'true': 'false';
 
     router.push({
     name: "RecordingSearchFilter",
     query: { term: recording_term,
             getRidOfInstrumentAndLive: getRidOfInstrumentAndLiveValue,
-            getExactMatch: getExactMatchValue,
+            getPartialMatch: getPartialMatchValue,
             artistName: artistName.value
             },
     });
@@ -94,7 +94,7 @@
   <div class="container px-4 my-4 border border-gray-700 py-4">
     <form v-on:submit.prevent="applyFilter">
       <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外  </label>
-      <label><input type="checkbox" v-model="selectFilter" value="getExactMatch">完全一致の曲のみ</label>
+      <label><input type="checkbox" v-model="selectFilter" value="getPartialMatch">部分一致の曲のみ</label>
       <br>
       <label>アーティスト名で絞り込み</label>
       <div class="relative">

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -43,7 +43,7 @@
     }
 
   const currentPage = ref(1);
-  const totalItems = ref(0);
+  const totalItems = ref<number>(NaN);
 
   const applyFilter = () :void  => {
     const getRidOfInstrumentAndLiveValue = selectFilter.value.includes("getRidOfInstrumentAndLive")? 'true': 'false';

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -3,7 +3,6 @@
   import { useRoute, RouterLink, onBeforeRouteUpdate } from "vue-router";
   import router from "../../router";
   import { ArtistCredit, SearchRecordingData } from "../../types/recording/RecordingSearch"
-  // import { RecordingSearchFilter } from "./RecordingSearchFilter.vue"
 
   onBeforeRouteUpdate((to, from, next) => {
     const second_recording_term = to.query.term;
@@ -60,8 +59,6 @@
     });
   }
 
-
-
   onMounted(async () => {
     await onClickHandler(currentPage.value);
 
@@ -85,15 +82,13 @@
 
     all_recording_data.value.push(new_recording_data);
     }
-    const flatted_recording_data = all_recording_data.value.flat();
-    // console.log(flatted_recording_data);
   })
 </script>
 
 <template>
   <div class="container px-4 my-4 border border-gray-700 py-4">
     <form v-on:submit.prevent="applyFilter">
-      <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外  </label>
+      <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外   </label>
       <label><input type="checkbox" v-model="selectFilter" value="getPartialMatch">部分一致の曲のみ</label>
       <br>
       <label>アーティスト名で絞り込み</label>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -37,7 +37,7 @@
     }
     const flatted_recording_data = all_recording_data.value.flat();
     console.log(flatted_recording_data)
-
+    recording_data.value = flatted_recording_data
   });
 
 
@@ -51,7 +51,7 @@
   const getRidOfInstrument = () => {
   const cutData = all_recording_data.value.flat()
     .filter((data) => !data.title.includes("Instrumental") && !data.title.includes("instrumental") && !data.title.includes("(Off Vocal)") && !data.title.includes("Music video") && !data.title.includes("TV Size"));
-    console.log(cutData);
+    recording_data.value = cutData
   }
 
 
@@ -62,7 +62,7 @@
 
 <template>
   <div>
-    <button v-on:click="getRidOfInstrument">絞り込み実行</button>
+    <button v-on:click="getRidOfInstrument">インスト音源を除外</button>
   </div>
   <table class="table-auto my-4">
     <thead>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -56,6 +56,13 @@
     console.log(recording_data.value)
   }
 
+  const getExactMatch = () => {
+  const ExactMatchData = recording_data.value
+    .filter((data) => data.title == recording_term);
+    recording_data.value = ExactMatchData
+    console.log(recording_data.value)
+  }
+
 
   const currentPage = ref(1);
   // const totalItems = ref(0);
@@ -65,6 +72,9 @@
 <template>
   <div>
     <button v-on:click="getRidOfInstrumentAndLive">インストとライブ音源を除外</button>
+  </div>
+  <div>
+    <button v-on:click="getExactMatch">完全一致の曲のみ</button>
   </div>
   <table class="table-auto my-4">
     <thead>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -8,9 +8,9 @@
   const getRidOfInstrumentAndLiveValue = route.query.getRidOfInstrumentAndLive;
   const getPartialMatchValue = route.query.getPartialMatch;
   const artistName = route.query.artistName as string || '';
-  let totalItems: number;
-  let filteredDataLength: number;
-  let filteredData: SearchRecordingData[];
+  const totalItems = ref<number>(0);
+  let filteredDataLength: number = 0;
+  let filteredData: SearchRecordingData[] = [];
 
   const recording_data = ref<SearchRecordingData[]>([]);
   const all_recording_data = ref<Array<SearchRecordingData[]>>([]);
@@ -19,8 +19,8 @@
     const first_res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=0&limit=100&fmt=json`)
     const first_data = await first_res.json();
 
-    totalItems = first_data.count - 1;
-    const repeat = totalItems < 1000 ? totalItems / 100  : 9;
+    totalItems.value = first_data.count - 1;
+    const repeat = totalItems.value < 1000 ? totalItems.value / 100  : 9;
 
     for(let i = 0; i < repeat + 1; i++) {
       const res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=${ i * 100 }&limit=100&fmt=json`)

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -1,26 +1,26 @@
 <script setup lang="ts">
-  import { ref, onMounted, reactive } from "vue";
+  import { ref, onMounted } from "vue";
   import { useRoute, RouterLink, onBeforeRouteUpdate } from "vue-router";
   import { ArtistCredit, SearchRecordingData } from "../../types/recording/RecordingSearch"
 
   const route = useRoute();
-  const recording_term = route.query.term;
+  let recording_term = route.query.term as string || '';
   const getRidOfInstrumentAndLiveValue = route.query.getRidOfInstrumentAndLive;
-  const getExactMatchValue = route.query.getExactMatchValue;
-  const totalItems = ref(0);
+  const getPartialMatchValue = route.query.getPartialMatch;
+  const artistName = route.query.artistName;
+  let totalItems: number;
+  let filteredDataLength: number;
+  let filteredData: SearchRecordingData[];
 
   const recording_data = ref<SearchRecordingData[]>([]);
   const all_recording_data = ref<Array<SearchRecordingData[]>>([]);
-
-  const selectFilter = reactive<string[]>([]);
-  const artistName = ref();
 
   onMounted(async() => {
     const first_res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=0&limit=100&fmt=json`)
     const first_data = await first_res.json();
 
-    totalItems.value = first_data.count - 1;
-    const repeat = totalItems.value < 1000 ? totalItems.value / 100  : 9;
+    totalItems = first_data.count - 1;
+    const repeat = totalItems < 1000 ? totalItems / 100  : 9;
 
     for(let i = 0; i < repeat + 1; i++) {
       const res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=${ i * 100 }&limit=100&fmt=json`)
@@ -41,22 +41,29 @@
 
     all_recording_data.value.push(new_recording_data);
     }
-    const flatted_recording_data = all_recording_data.value.flat();
-    console.log(flatted_recording_data)
-    recording_data.value = flatted_recording_data
+    recording_data.value = all_recording_data.value.flat();
+
+    if(getRidOfInstrumentAndLiveValue == "true"){
+      getRidOfInstrumentAndLive()
+    }
+
+    if(getPartialMatchValue == "true"){
+      getPartialMatch()
+    }
+    filteredData = recording_data.value;
+    filteredDataLength = filteredData.length;
+
   });
 
 
   const onClickHandler = (page: number) => {
-    const initialData = [...recording_data.value];
     let startIndex = (page - 1) * 100;
     let endIndex = startIndex + 99;
-    const dataPerPage = initialData.slice(startIndex , endIndex)
-    const newData = [...dataPerPage];
-    recording_data.value = newData;
+    const dataPerPage = filteredData.slice(startIndex , endIndex)
+    recording_data.value = dataPerPage;
   }
 
-  const artistFilter = (): void => {
+  const artistFilter = () => {
     //入力したアーティスト名が、flatted_recording_dataの「artist-credit」のnameに含まれているものの配列を返したい
   }
 
@@ -64,37 +71,23 @@
   const cutData = recording_data.value
     .filter((data) => !data.title.includes("Instrumental") && !data.title.includes("instrumental") && !data.title.includes("(Off Vocal)") && !data.title.includes("(off vocal)") && !data.title.includes("Music video") && !data.title.includes("TV Size")&& data["secondary-types"]  !== "Live");
     recording_data.value = cutData
-    totalItems.value = cutData.length
   }
 
-  const getExactMatch = () => {
-  const ExactMatchData = recording_data.value
-    .filter((data) => data.title == recording_term);
-    recording_data.value = ExactMatchData
-    totalItems.value = ExactMatchData.length
+  const getPartialMatch = () => {
+  const partialMatchData = recording_data.value
+    .filter((data) => data.title.includes(recording_term));
+    recording_data.value = partialMatchData
   }
-
-  const applyFilter = () :void  => {
-    if(selectFilter.includes("getRidOfInstrumentAndLive")){
-      getRidOfInstrumentAndLive
-      console.log('inst')
-    }
-    if(selectFilter.includes("getExactMatch")){
-      getExactMatch
-      console.log('exact')
-    }
-  }
-
 
   const currentPage = ref(1);
 
 </script>
 
 <template>
-    <div class="container px-4 my-4 border border-gray-700 py-4">
+    <!-- <div class="container px-4 my-4 border border-gray-700 py-4">
       <form v-on:submit.prevent="applyFilter">
         <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外  </label>
-        <label><input type="checkbox" v-model="selectFilter" value="getExactMatch">完全一致の曲のみ</label>
+        <label><input type="checkbox" v-model="selectFilter" value="getPartialMatch">完全一致の曲のみ</label>
         <br>
         <label>アーティスト名で絞り込み</label>
         <div class="relative">
@@ -103,13 +96,13 @@
             <button type="submit" class="text-white absolute right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800">適用</button>
           </div>
       </form>
-    </div>
+    </div> -->
 
   <!-- <div>
     <button v-on:click="getRidOfInstrumentAndLive">インストとライブ音源を除外</button>
   </div>
   <div>
-    <button v-on:click="getExactMatch">完全一致の曲のみ</button>
+    <button v-on:click="getPartialMatch">完全一致の曲のみ</button>
   </div> -->
   <table class="table-auto my-4">
     <thead>
@@ -132,7 +125,7 @@
     </tbody>
   </table>
   <vue-awesome-paginate
-    :total-items="totalItems"
+    :total-items="filteredDataLength"
     :items-per-page="100"
     :max-pages-shown="5"
     v-model="currentPage"

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
-  import { ref, onMounted } from "vue";
+  import { ref, onMounted, reactive } from "vue";
   import { useRoute, RouterLink, onBeforeRouteUpdate } from "vue-router";
   import { ArtistCredit, SearchRecordingData } from "../../types/recording/RecordingSearch"
 
   const route = useRoute();
   const recording_term = route.query.term;
+  const getRidOfInstrumentAndLiveValue = route.query.getRidOfInstrumentAndLive;
+  const getExactMatchValue = route.query.getExactMatchValue;
   const totalItems = ref(0);
 
   const recording_data = ref<SearchRecordingData[]>([]);
   const all_recording_data = ref<Array<SearchRecordingData[]>>([]);
+
+  const selectFilter = reactive<string[]>([]);
+  const artistName = ref();
 
   onMounted(async() => {
     const first_res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=0&limit=100&fmt=json`)
@@ -42,7 +47,13 @@
   });
 
 
-  const onClickHandler = async (page: number) => {
+  const onClickHandler = (page: number) => {
+    const initialData = [...recording_data.value];
+    let startIndex = (page - 1) * 100;
+    let endIndex = startIndex + 99;
+    const dataPerPage = initialData.slice(startIndex , endIndex)
+    const newData = [...dataPerPage];
+    recording_data.value = newData;
   }
 
   const artistFilter = (): void => {
@@ -51,31 +62,55 @@
 
   const getRidOfInstrumentAndLive = () => {
   const cutData = recording_data.value
-    .filter((data) => !data.title.includes("Instrumental") && !data.title.includes("instrumental") && !data.title.includes("(Off Vocal)") && !data.title.includes("Music video") && !data.title.includes("TV Size")&& data["secondary-types"]  !== "Live");
+    .filter((data) => !data.title.includes("Instrumental") && !data.title.includes("instrumental") && !data.title.includes("(Off Vocal)") && !data.title.includes("(off vocal)") && !data.title.includes("Music video") && !data.title.includes("TV Size")&& data["secondary-types"]  !== "Live");
     recording_data.value = cutData
-    console.log(recording_data.value)
+    totalItems.value = cutData.length
   }
 
   const getExactMatch = () => {
   const ExactMatchData = recording_data.value
     .filter((data) => data.title == recording_term);
     recording_data.value = ExactMatchData
-    console.log(recording_data.value)
+    totalItems.value = ExactMatchData.length
+  }
+
+  const applyFilter = () :void  => {
+    if(selectFilter.includes("getRidOfInstrumentAndLive")){
+      getRidOfInstrumentAndLive
+      console.log('inst')
+    }
+    if(selectFilter.includes("getExactMatch")){
+      getExactMatch
+      console.log('exact')
+    }
   }
 
 
   const currentPage = ref(1);
-  // const totalItems = ref(0);
 
 </script>
 
 <template>
-  <div>
+    <div class="container px-4 my-4 border border-gray-700 py-4">
+      <form v-on:submit.prevent="applyFilter">
+        <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外  </label>
+        <label><input type="checkbox" v-model="selectFilter" value="getExactMatch">完全一致の曲のみ</label>
+        <br>
+        <label>アーティスト名で絞り込み</label>
+        <div class="relative">
+          <input v-model="artistName" type="search" id="search" class=" p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="アーティスト名を入力" />
+            <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none"></div>
+            <button type="submit" class="text-white absolute right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800">適用</button>
+          </div>
+      </form>
+    </div>
+
+  <!-- <div>
     <button v-on:click="getRidOfInstrumentAndLive">インストとライブ音源を除外</button>
   </div>
   <div>
     <button v-on:click="getExactMatch">完全一致の曲のみ</button>
-  </div>
+  </div> -->
   <table class="table-auto my-4">
     <thead>
       <tr>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -30,7 +30,8 @@
           join_phrase: credit.joinphrase,
           all_name: credit.artist.name + (credit.joinphrase ? ' ' + credit.joinphrase : '')
         })),
-        first_release_date: item["first-release-date"]
+        first_release_date: item["first-release-date"],
+        "secondary-types": item.releases?.[0]["release-group"]["secondary-types"]?.[0]
       }))
 
     all_recording_data.value.push(new_recording_data);
@@ -48,10 +49,11 @@
     //入力したアーティスト名が、flatted_recording_dataの「artist-credit」のnameに含まれているものの配列を返したい
   }
 
-  const getRidOfInstrument = () => {
-  const cutData = all_recording_data.value.flat()
-    .filter((data) => !data.title.includes("Instrumental") && !data.title.includes("instrumental") && !data.title.includes("(Off Vocal)") && !data.title.includes("Music video") && !data.title.includes("TV Size"));
+  const getRidOfInstrumentAndLive = () => {
+  const cutData = recording_data.value
+    .filter((data) => !data.title.includes("Instrumental") && !data.title.includes("instrumental") && !data.title.includes("(Off Vocal)") && !data.title.includes("Music video") && !data.title.includes("TV Size")&& data["secondary-types"]  !== "Live");
     recording_data.value = cutData
+    console.log(recording_data.value)
   }
 
 
@@ -62,7 +64,7 @@
 
 <template>
   <div>
-    <button v-on:click="getRidOfInstrument">インスト音源を除外</button>
+    <button v-on:click="getRidOfInstrumentAndLive">インストとライブ音源を除外</button>
   </div>
   <table class="table-auto my-4">
     <thead>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref, onMounted } from "vue";
-  import { useRoute, RouterLink, onBeforeRouteUpdate } from "vue-router";
+  import { useRoute, RouterLink } from "vue-router";
   import { ArtistCredit, SearchRecordingData } from "../../types/recording/RecordingSearch"
 
   const route = useRoute();
@@ -59,7 +59,6 @@
 
   });
 
-
   const onClickHandler = (page: number) => {
     let startIndex = (page - 1) * 100;
     let endIndex = startIndex + 99;
@@ -86,7 +85,6 @@
   }
 
   const currentPage = ref(1);
-
 </script>
 
 <template>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -7,7 +7,7 @@
   let recording_term = route.query.term as string || '';
   const getRidOfInstrumentAndLiveValue = route.query.getRidOfInstrumentAndLive;
   const getPartialMatchValue = route.query.getPartialMatch;
-  const artistName = route.query.artistName;
+  const artistName = route.query.artistName as string || '';
   let totalItems: number;
   let filteredDataLength: number;
   let filteredData: SearchRecordingData[];
@@ -50,6 +50,10 @@
     if(getPartialMatchValue == "true"){
       getPartialMatch()
     }
+
+    if(artistName !== ""){
+      artistFilter()
+    }
     filteredData = recording_data.value;
     filteredDataLength = filteredData.length;
 
@@ -64,7 +68,9 @@
   }
 
   const artistFilter = () => {
-    //入力したアーティスト名が、flatted_recording_dataの「artist-credit」のnameに含まれているものの配列を返したい
+    const includeArtistData = recording_data.value
+    .filter((data) => data["artist-credit"][0].all_name.includes(artistName));
+    recording_data.value = includeArtistData
   }
 
   const getRidOfInstrumentAndLive = () => {
@@ -84,26 +90,6 @@
 </script>
 
 <template>
-    <!-- <div class="container px-4 my-4 border border-gray-700 py-4">
-      <form v-on:submit.prevent="applyFilter">
-        <label><input type="checkbox" v-model="selectFilter" value="getRidOfInstrumentAndLive">インストとライブ音源を除外  </label>
-        <label><input type="checkbox" v-model="selectFilter" value="getPartialMatch">完全一致の曲のみ</label>
-        <br>
-        <label>アーティスト名で絞り込み</label>
-        <div class="relative">
-          <input v-model="artistName" type="search" id="search" class=" p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="アーティスト名を入力" />
-            <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none"></div>
-            <button type="submit" class="text-white absolute right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800">適用</button>
-          </div>
-      </form>
-    </div> -->
-
-  <!-- <div>
-    <button v-on:click="getRidOfInstrumentAndLive">インストとライブ音源を除外</button>
-  </div>
-  <div>
-    <button v-on:click="getPartialMatch">完全一致の曲のみ</button>
-  </div> -->
   <table class="table-auto my-4">
     <thead>
       <tr>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,6 +14,13 @@ const routeSettings: RouteRecordRaw[] = [
     name: 'RecordingSearch',
     component: () => {
       return import("../components/recordings/RecordingSearch.vue");
+    },
+  },
+    {
+    path: '/recordings/filter',
+    name: 'RecordingSearchFilter',
+    component: () => {
+      return import("../components/recordings/RecordingSearchFilter.vue");
     }
   },
 

--- a/src/types/recording/RecordingSearch.ts
+++ b/src/types/recording/RecordingSearch.ts
@@ -8,6 +8,11 @@ export type ArtistCredit = {
   joinphrase: string;
   all_name: string;
 }
+export type secondaryType = {
+  "release-group": {
+    "secondary-types": Array<string>;
+  }
+}
 
 export type SearchRecordingData  = {
   id: string;
@@ -15,4 +20,6 @@ export type SearchRecordingData  = {
   "artist-credit": ArtistCredit[];
   "first-release-date": string;
   first_release_date: string;
+  releases: secondaryType[];
+  "secondary-types": string;
   };


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/112
https://github.com/fuwa-syugyo/credit_search/issues/113
https://github.com/fuwa-syugyo/credit_search/issues/114

## 概要
曲検索結果画面に以下の絞り込み機能を追加した。
* インスト音源、ライブ音源の除外(厳密ではない)
* 部分一致検索
* アーティスト名による絞り込み

リリース日による並び替え機能についてはひとまず見送り。
できそうではあるが、データだと文字列であるためちょっと大変そう。