### PR TITLE
検索結果画面でページを変更するとtermがundefinedになる不具合を修正

### DIFF
--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -15,6 +15,7 @@
   const artist_data = ref<ArtistData[]>([]);
 
   const onClickHandler = async (page: number, artist_term: string) => {
+    artist_term = route.query.term as string || '';
     const offset = (page - 1) * 100
     const res = await fetch(`https://musicbrainz.org/ws/2/artist/?query=artist:${artist_term}&offset=${offset}&limit=100&fmt=json`)
     const data = await res.json();

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -19,6 +19,7 @@
   const artistName = ref();
 
   const onClickHandler = async (page: number, recording_term: string) => {
+    recording_term = route.query.term as string || '';
     const offset = (page - 1) * 100
     const res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=${offset}&limit=100&fmt=json`)
     const data = await res.json();


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/128

## 概要
検索結果でページを変更すると検索単語が`undefined`になってしまう不具合を修正した。