### PR TITLE
連続して検索するテストを追加

### DIFF
--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -43,4 +43,18 @@ describe('template spec', () => {
     .contains('keyboard').parent()
     .contains('小室哲哉')
   });
+
+  it('Continuously artist search', () => {
+    cy.visit('http://127.0.0.1:5173/')
+
+    cy.get('[value="人物名"]').check();
+    cy.get('#search').type('YOASOBI{enter}', {force: true});
+    cy.contains('検索').click();
+    cy.contains('YOASOBI')
+
+    cy.get('#search').focus().clear()
+    .type('the band apart{enter}', {force: true});
+    cy.contains('検索').first().click();
+    cy.contains('the band apart')
+  })
 })

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -45,7 +45,6 @@ describe('Recording search and lookup artist', () => {
     .contains('drums (drum set)');
   })
 
-
   it('Visits recording search result has not Spotify link', () => {
     cy.visit('http://127.0.0.1:5173/')
 
@@ -55,5 +54,18 @@ describe('Recording search and lookup artist', () => {
 
     cy.contains('青春青春').click()
     cy.get('body').should('not.contain', 'Spotifyで聴く')
+  })
+
+  it('Continuously recording search', () => {
+    cy.visit('http://127.0.0.1:5173/')
+
+    cy.get('#search').type('ミックスナッツ{enter}', {force: true});
+    cy.contains('検索').click();
+    cy.contains('ミックスナッツ')
+
+    cy.get('#search').focus().clear()
+    .type('マリーゴールド{enter}', {force: true});
+    cy.contains('検索').first().click();
+    cy.contains('マリーゴールド')
   })
 })

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -77,7 +77,7 @@
       <br>
       <label>アーティスト名で絞り込み</label>
       <div class="relative">
-        <input v-model="artistName" type="search" id="search" class=" p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="アーティスト名を入力" />
+        <input v-model="artistName" type="search" id="filter" class=" p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="アーティスト名を入力" />
           <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none"></div>
           <button type="submit" class="text-white absolute right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800">適用</button>
       </div>


### PR DESCRIPTION
## issue 
https://github.com/fuwa-syugyo/credit_search/issues/154

## 概要
楽曲検索と人物検索それぞれについて、連続して検索できるかのテストを追加した。
過去に検索結果画面が表示されている状態で同じ検索対象で別の検索を行うと画面が更新されない不具合が発生していたので、その検知のため。
楽曲検索画面でヘッダーの検索フォームとフィルターの入力フォームに同じidが割り振られており、前者をテストで指定するために後者のidを変更した。