### PR TITLE
ページネーションの部分に件数を表示した

### DIFF
--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -141,6 +141,8 @@
     <br>
     <div v-if="artistRecording?.length !== 0">
       アーティストとして関わった楽曲
+      <br>
+      {{ totalItems + ' 件中 ' + ((currentPage - 1) * 100 + 1 ) + ' 〜 ' +  ((currentPage - 1) * 100  + (artistRecording?.length ?? 0))+ '件'  }}
       <table class="artist-table table-auto my-4">
         <thead>
           <tr>

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -34,7 +34,7 @@
       }))
 
       artist_data.value = new_artist_data;
-      totalItems.value = data.count - 1;
+      totalItems.value = data.count;
     } catch {
       console.error('Error fetching data:', Error);
     } finally {
@@ -55,6 +55,7 @@
     <NowLoading></NowLoading>
   </div>
   <div v-else-if="artist_data.length !== 0">
+    {{ '検索結果 '+ totalItems + ' 件中 ' + ((currentPage - 1) * 100 + 1 ) + ' 〜 ' +  ((currentPage - 1) * 100  + artist_data.length)+ '件'  }}
     <table class="table-auto my-4">
       <thead>
         <tr>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -45,7 +45,7 @@
       }))
 
       recording_data.value = new_recording_data;
-      totalItems.value = data.count - 1;
+      totalItems.value = data.count;
     } catch {
       console.error('Error fetching data:', Error);
     } finally {
@@ -93,6 +93,7 @@
         </div>
       </form>
     </div>
+    {{ '検索結果 '+ totalItems + ' 件中 ' + ((currentPage - 1) * 100 + 1 ) + ' 〜 ' +  ((currentPage - 1) * 100  + recording_data.length)+ '件'  }}
     <table class="table-auto my-4">
       <thead>
         <tr>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -23,7 +23,7 @@
       const first_res = await fetch(`https://musicbrainz.org/ws/2/recording/?query=recording:${recording_term}&offset=0&limit=100&fmt=json`)
       const first_data = await first_res.json();
 
-      totalItems.value = first_data.count - 1;
+      totalItems.value = first_data.count;
       const repeat = totalItems.value < 500 ? totalItems.value / 100  : 4;
 
     for(let i = 0; i < repeat + 1; i++) {
@@ -100,6 +100,7 @@
     <NowLoading></NowLoading>
   </div>
   <div v-else-if="filteredDataLength !== 0">
+    {{ '検索結果 '+ filteredDataLength + ' 件中 ' + ((currentPage - 1) * 100 + 1 ) + ' 〜 ' +  ((currentPage - 1) * 100  + recording_data.length)+ '件'  }}
     <table class="table-auto my-4">
       <thead>
         <tr>


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/158

## 概要
ページネーションがある部分に、全体の件数と現在表示している件数の表示を追加した。
`totalItems`の数が誤っていたので修正した。