### PR TITLE
レスポンシブデザイン対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>タイトル募集中</title>
+    <title>Simple Music Credit Search</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,16 +4,16 @@ import { RouterLink } from "vue-router";
 </script>
 
 <template>
-  <div class="container  border-b-4">
-    <div class="px-4 my-4 w-[500px]">
-    <router-link to="/">
-      <div class="header__logo-box">
-        <img src="../../public/logo.png" alt="Logo" class="header__logo" style="height: 100px;">
+  <div class="container  border-b-4 mb-2">
+    <div class="my-4 w-full md:w-[500px]">
+      <router-link to="/">
+        <div class="header__logo-box">
+          <img src="../../public/logo.png" alt="Logo" class="header__logo" style="height: 100px;">
+        </div>
+      </router-link>
+      <div class="my-4">
+        <SearchForm />
       </div>
-    </router-link>
-    <div class="px-4 my-4">
-      <SearchForm />
     </div>
-  </div>
   </div>
 </template>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -14,11 +14,15 @@ const search = (): void => {
 </script>
 
 <template>
-  <div class="container px-4 my-4">
+  <div class="container my-4">
     <form v-on:submit.prevent="search" id="search-form">
-      <input type="radio" v-model="searchType" value="曲名">曲名
-      <input type="radio" v-model="searchType" value="人物名">人物名
-      <div class="relative">
+      <label for="recording" class="mr-[5px]"><input type="radio" v-model="searchType" value="曲名" id="recording">
+        <span>曲名</span>
+      </label>
+      <label for="artist"><input type="radio" v-model="searchType" value="人物名" id="artist">
+        <span>人物名</span>
+      </label>
+      <div class="relative md:w-3/4">
       <input v-model="term" type="search" id="search" class="block w-full p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="検索" required />
         <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
             <svg aria-hidden="true" class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -151,7 +151,7 @@
       <vue-awesome-paginate
         :total-items="totalItems"
         :items-per-page="100"
-        :max-pages-shown="5"
+        :max-pages-shown="3"
         v-model="currentPage"
         :on-click="onClickHandler"
       />
@@ -192,5 +192,39 @@
 
   .active-page:hover {
     background-color: #2988c8;
+  }
+
+  /* スマートフォン用のスタイル */
+  @media (max-width: 768px) {
+    .pagination-container {
+      display: flex;
+      column-gap: 5px;
+    }
+
+    .paginate-buttons {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 25px;
+      width: 35px;
+      border-radius: 5px;
+      cursor: pointer;
+      background-color: rgb(242, 242, 242);
+      border: 1px solid rgb(217, 217, 217);
+      color: black;
+    }
+
+    .paginate-buttons:hover {
+      background-color: #d8d8d8;
+    }
+
+    .active-page {
+      background-color: #3498db;
+      color: white;
+    }
+
+    .active-page:hover {
+      background-color: #2988c8;
+    }
   }
 </style>

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -76,7 +76,7 @@
       <vue-awesome-paginate
         :total-items="totalItems"
         :items-per-page="100"
-        :max-pages-shown="5"
+        :max-pages-shown="3"
         v-model="currentPage"
         :on-click="onClickHandler"
       />
@@ -118,5 +118,39 @@
   
   .active-page:hover {
     background-color: #2988c8;
+  }
+
+      /* スマートフォン用のスタイル */
+  @media (max-width: 768px) {
+    .pagination-container {
+      display: flex;
+      column-gap: 5px;
+    }
+
+    .paginate-buttons {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 25px;
+      width: 35px;
+      border-radius: 5px;
+      cursor: pointer;
+      background-color: rgb(242, 242, 242);
+      border: 1px solid rgb(217, 217, 217);
+      color: black;
+    }
+
+    .paginate-buttons:hover {
+      background-color: #d8d8d8;
+    }
+
+    .active-page {
+      background-color: #3498db;
+      color: white;
+    }
+
+    .active-page:hover {
+      background-color: #2988c8;
+    }
   }
 </style>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -83,7 +83,7 @@
     <div class="px-4 my-4 border border-gray-500 py-4  md:w-[350px] w-[250px] rounded-md">
       <form v-on:submit.prevent="applyFilter">
         <p class="text-xl mb-2">絞り込み</p>
-        <div class="bg-slate-100 flex-col">
+        <div class="bg-slate-100 flex-col mb-2">
           <label for="inst" class="mr-[10px] flex"><input type="checkbox" v-model="selectFilter" value="getRidOfInstrument" id="inst">
             <span>インスト音源以外</span>
           </label>
@@ -91,10 +91,9 @@
             <span>部分一致の曲</span>
           </label>
         </div>
-        <br>
         <label>アーティスト名</label>
         <div class="relative">
-          <input v-model="artistName" type="search" id="filter" class=" p-2 pl-2 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 my-2" placeholder="アーティスト名を入力" />
+          <input v-model="artistName" type="search" id="filter" class=" p-2 pl-2 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 my-1" placeholder="アーティスト名を入力" />
             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none"></div>
             <button type="submit" class="text-white right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800 md:mx-2">適用</button>
         </div>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -80,23 +80,23 @@
     <NowLoading></NowLoading>
   </div>
   <div v-else-if="recording_data.length !== 0" class="container">
-    <div class="px-4 my-4 border border-gray-500 py-4 w-[400px] rounded-md">
+    <div class="px-4 my-4 border border-gray-500 py-4  md:w-[350px] w-[250px] rounded-md">
       <form v-on:submit.prevent="applyFilter">
         <p class="text-xl mb-2">絞り込み</p>
-        <div class="bg-slate-100">
-          <label for="inst" class="mr-[10px]"><input type="checkbox" v-model="selectFilter" value="getRidOfInstrument" id="inst">
-            <span>インスト音源を除外</span>
+        <div class="bg-slate-100 flex-col">
+          <label for="inst" class="mr-[10px] flex"><input type="checkbox" v-model="selectFilter" value="getRidOfInstrument" id="inst">
+            <span>インスト音源以外</span>
           </label>
-          <label for="partial"><input type="checkbox" v-model="selectFilter" value="getPartialMatch" id="partial">
-            <span>部分一致の曲のみ</span>
+          <label for="partial" class="flex"><input type="checkbox" v-model="selectFilter" value="getPartialMatch" id="partial">
+            <span>部分一致の曲</span>
           </label>
         </div>
         <br>
-        <label>アーティスト名で絞り込み</label>
+        <label>アーティスト名</label>
         <div class="relative">
-          <input v-model="artistName" type="search" id="filter" class=" p-4 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="アーティスト名を入力" />
+          <input v-model="artistName" type="search" id="filter" class=" p-2 pl-2 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 my-2" placeholder="アーティスト名を入力" />
             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none"></div>
-            <button type="submit" class="text-white absolute right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800">適用</button>
+            <button type="submit" class="text-white right-3.5 bottom-2.5 bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-green-300 dark:hover:bg-green-400 dark:focus:ring-green-800 md:mx-2">適用</button>
         </div>
       </form>
     </div>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -106,7 +106,7 @@
         <tr>
           <th class="px-4 py-2 border w-[400px] bg-blue-100">曲名</th>
           <th class="px-4 py-2 border w-[400px] bg-blue-100">アーティスト</th>
-          <th class="px-4 py-2 border w-[130px] bg-blue-100">リリース日</th>
+          <th class="px-4 py-2 border w-[130px] bg-blue-100 hidden md:inline-block">リリース日</th>
         </tr>
       </thead>
       <tbody>
@@ -117,7 +117,7 @@
             </RouterLink>
           </td>
           <td class="border px-4 py-2">{{ recording["artist-credit"].map((credit: ArtistCredit) => credit.all_name).join(' ') }}</td>
-          <td class="text-center border px-4 py-2 w-[130px]">{{ recording.first_release_date }}</td>
+          <td class="text-center border px-4 py-2 w-[130px] hidden md:inline-block">{{ recording.first_release_date }}</td>
         </tr>
       </tbody>
     </table>
@@ -125,7 +125,7 @@
       <vue-awesome-paginate
         :total-items="totalItems"
         :items-per-page="100"
-        :max-pages-shown="5"
+        :max-pages-shown="3"
         v-model="currentPage"
         :on-click="onClickHandler"
       />
@@ -166,5 +166,39 @@
 
   .active-page:hover {
     background-color: #2988c8;
+  }
+
+    /* スマートフォン用のスタイル */
+  @media (max-width: 768px) {
+    .pagination-container {
+      display: flex;
+      column-gap: 5px;
+    }
+
+    .paginate-buttons {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 25px;
+      width: 35px;
+      border-radius: 5px;
+      cursor: pointer;
+      background-color: rgb(242, 242, 242);
+      border: 1px solid rgb(217, 217, 217);
+      color: black;
+    }
+
+    .paginate-buttons:hover {
+      background-color: #d8d8d8;
+    }
+
+    .active-page {
+      background-color: #3498db;
+      color: white;
+    }
+
+    .active-page:hover {
+      background-color: #2988c8;
+    }
   }
 </style>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -106,7 +106,7 @@
         <tr>
           <th class="px-4 py-2 border w-[400px] bg-blue-100">曲名</th>
           <th class="px-4 py-2 border w-[400px] bg-blue-100">アーティスト</th>
-          <th class="px-4 py-2 border w-[130px] bg-blue-100">リリース日</th>
+          <th class="px-4 py-2 border w-[130px] bg-blue-100 hidden md:inline-block">リリース日</th>
         </tr>
       </thead>
       <tbody>
@@ -117,7 +117,7 @@
             </RouterLink>
           </td>
           <td class="border px-4 py-2">{{ recording["artist-credit"].map((credit: ArtistCredit) => credit.all_name).join(' ') }}</td>
-          <td class="text-center border px-4 py-2">{{ recording.first_release_date }}</td>
+          <td class="text-center border px-4 py-2 hidden md:inline-block">{{ recording.first_release_date }}</td>
         </tr>
       </tbody>
     </table>
@@ -125,7 +125,7 @@
       <vue-awesome-paginate
         :total-items="filteredDataLength"
         :items-per-page="100"
-        :max-pages-shown="5"
+        :max-pages-shown="3"
         v-model="currentPage"
         :on-click="onClickHandler"
       />
@@ -167,4 +167,39 @@
   .active-page:hover {
     background-color: #2988c8;
   }
+  
+  /* スマートフォン用のスタイル */
+   @media (max-width: 768px) {
+    .pagination-container {
+      display: flex;
+      column-gap: 5px;
+    }
+
+    .paginate-buttons {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 25px;
+      width: 35px;
+      border-radius: 5px;
+      cursor: pointer;
+      background-color: rgb(242, 242, 242);
+      border: 1px solid rgb(217, 217, 217);
+      color: black;
+    }
+
+    .paginate-buttons:hover {
+      background-color: #d8d8d8;
+    }
+
+    .active-page {
+      background-color: #3498db;
+      color: white;
+    }
+
+    .active-page:hover {
+      background-color: #2988c8;
+    }
+  }
+
 </style>


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/159

## 概要
* レスポンシブデザイン対応(ヘッダーのサイズ変更と楽曲検索結果のリリース日列非表示)
* ヘッダーなどの見た目の調整
* タイトルを表示
* ページネーションの表示ボタンを5→3に
