### PR TITLE
フィルター結果画面の件数表示と指定を修正

### DIFF
--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -60,6 +60,7 @@
     }
     filteredData = recording_data.value;
     filteredDataLength = filteredData.length;
+    onClickHandler(currentPage.value)
     } catch {
       console.error('Error fetching data:', Error);
     } finally {
@@ -69,7 +70,7 @@
 
   const onClickHandler = (page: number) => {
     let startIndex = (page - 1) * 100;
-    let endIndex = startIndex + 99;
+    let endIndex = startIndex + 100;
     const dataPerPage = filteredData.slice(startIndex , endIndex)
     recording_data.value = dataPerPage;
   }


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/168

## 概要
フィルター結果がおかしい部分を修正。`slice`メソッドの終点の指定が誤っていた。
* `onMounted` で `onClickHandler`を呼び出し、最初の件数の表示がおかしいのを修正
* 99件しか表示されていないのを修正